### PR TITLE
Add systemd support for dhtnode and dhtdump

### DIFF
--- a/deploy/systemd/dht@.service
+++ b/deploy/systemd/dht@.service
@@ -1,0 +1,35 @@
+# Runs a dhtnode instance
+
+[Unit]
+Description=Distributed Hash Table instance %I
+AssertPathExists=/srv/dhtnode/dhtnode-%i
+Requires=network-online.target local-fs.target
+After=network-online.target local-fs.target
+#StartLimitIntervalSec=
+#StartLimitBurts=
+
+[Service]
+Type=simple
+WorkingDirectory=/srv/dhtnode/dhtnode-%i/
+ExecStart=/usr/sbin/dhtnode -c /srv/dhtnode/dhtnode-%i/etc/config.ini
+ExecReload=/bin/kill -HUP $MAINPID
+
+# SIGKILL only manually
+TimeoutStopSec=infinity
+SendSIGKILL=no
+Restart=on-failure
+User=dhtnode
+Group=core
+
+# Could be even 1000 (to disable oom killing),
+# but set to -950 for the OOM killer to be able to kill an instance
+# of DHT node if the server is about to die.
+OOMScoreAdjust=-950
+
+# Note infinity is used instead of unlimited
+LimitNOFILE=100000:100000
+LimitMEMLOCK=infinity:infinity
+LimitCORE=infinity:infinity
+
+[Install]
+WantedBy = multi-user.target

--- a/deploy/systemd/dhtdump@.service
+++ b/deploy/systemd/dhtdump@.service
@@ -1,0 +1,29 @@
+# Runs a dhtdump instance
+
+[Unit]
+Description=DHT dump instance %I
+AssertPathExists=/srv/dhtnode/dhtnode-%i/dump/
+Requires=network-online.target local-fs.target
+After=network-online.target local-fs.target dht@%i.service
+#StartLimitIntervalSec=
+#StartLimitBurts=
+
+[Service]
+Type=simple
+WorkingDirectory=/srv/dhtnode/dhtnode-%i/dump
+ExecStart=/usr/sbin/dhtdump -c /srv/dhtnode/dhtnode-%i/dump/etc/config.ini
+ExecReload=/bin/kill -HUP $MAINPID
+
+# SIGKILL only manually
+TimeoutStopSec=infinity
+SendSIGKILL=no
+Restart=on-failure
+User=dhtnode
+Group=core
+
+# Note infinity is used instead of unlimited
+LimitNOFILE=100000:100000
+LimitCORE=infinity:infinity
+
+[Install]
+WantedBy = multi-user.target

--- a/pkg/dhtnode-common.pkg
+++ b/pkg/dhtnode-common.pkg
@@ -17,6 +17,8 @@ ARGS = FUN.mapfiles('deploy/logrotate', '/etc/logrotate.d',
         ('dhtnode-logs', 'dhtdump-logs'), append_suffix=False) + \
     [
         "README.rst=/usr/share/doc/" + VAR.shortname + "/README.rst",
+        "deploy/systemd/dht@.service=/lib/systemd/system/dht@.service",
+        "deploy/systemd/dhtdump@.service=/lib/systemd/system/dhtdump@.service"
     ]
 
 # vim: set ft=python et sw=4 sts=4 :


### PR DESCRIPTION
This commit removes upstart scripts and changes the package to use
systemd init system instead of upstart. Note that the packages
installed from this point will not include any support for upstart.

Fixes #3