### PR TITLE
Cherries from v1.9.7 - v1.9.10

### DIFF
--- a/deploy/upstart/dhtdump-instance.conf
+++ b/deploy/upstart/dhtdump-instance.conf
@@ -11,11 +11,6 @@ stop on stopping dhtdump
 # Instance name
 instance $INSTANCE
 
-# This stanza allows upstart to keep track of a process which has forked once.
-# The script stanza, below, appears to be forked already. dhtdump does not fork
-# itself specifically, so this means that we have forked once in total.
-expect fork
-
 # When stopping the service, we need to give the process some time to shut down
 # before attempting to kill it. dhtdump doesn't have any special shutdown
 # behaviour, so we just give it 5 seconds.
@@ -44,6 +39,6 @@ setgid core
 # run, per instance (e.g. for test or release candidate deployments).
 script
     cd /srv/dhtnode/dhtnode-$INSTANCE/dump/
-    "/srv/dhtnode/dhtnode-$INSTANCE/dump/dhtdump" "--config=/srv/dhtnode/dhtnode-$INSTANCE/dump/etc/config.ini"
+    exec "/srv/dhtnode/dhtnode-$INSTANCE/dump/dhtdump" "--config=/srv/dhtnode/dhtnode-$INSTANCE/dump/etc/config.ini"
     # TODO: also pass instance number to exe (not currently needed)
 end script

--- a/deploy/upstart/dhtnode-instance.conf
+++ b/deploy/upstart/dhtnode-instance.conf
@@ -11,11 +11,6 @@ stop on stopping dht
 # Instance name
 instance $INSTANCE
 
-# This stanza allows upstart to keep track of a process which has forked once.
-# The script stanza, below, appears to be forked already. dhtnode does not fork
-# itself specifically, so this means that we have forked once in total.
-expect fork
-
 # When stopping the service, we need to give the process some time to shut down
 # before attempting to kill it. The dhtnode has to dump its data to disk. We
 # don't want to interrupt this, so we set a very high timeout here (one hour).
@@ -45,6 +40,6 @@ setgid core
 # run, per instance (e.g. for test or release candidate deployments).
 script
     cd /srv/dhtnode/dhtnode-$INSTANCE/
-    "/srv/dhtnode/dhtnode-$INSTANCE/dhtnode" "--config=/srv/dhtnode/dhtnode-$INSTANCE/etc/config.ini"
+    exec "/srv/dhtnode/dhtnode-$INSTANCE/dhtnode" "--config=/srv/dhtnode/dhtnode-$INSTANCE/etc/config.ini"
     # TODO: also pass instance number to exe (not currently needed)
 end script

--- a/src/dhtnode/dhtdump/main.d
+++ b/src/dhtnode/dhtdump/main.d
@@ -80,10 +80,20 @@ static this ( )
 
 private int main ( istring[] cl_args )
 {
-    auto app = new DhtDump;
-    return app.main(cl_args);
+    try
+    {
+        auto app = new DhtDump;
+        auto ret = app.main(cl_args);
+        log.info("Exiting with return code {}", ret);
+        return ret;
+    }
+    catch ( Throwable e )
+    {
+        log.error("Caught exception in main: {} @ {}:{}",
+            getMsg(e), e.file, e.line);
+        throw e;
+    }
 }
-
 
 
 public class DhtDump : DaemonApp

--- a/src/dhtnode/main.d
+++ b/src/dhtnode/main.d
@@ -26,6 +26,8 @@ import ocean.util.app.DaemonApp;
 
 import ocean.util.log.Log;
 
+import core.memory;
+
 
 
 /*******************************************************************************
@@ -276,6 +278,13 @@ public class DhtNodeServer : DaemonApp
 
     public this ( )
     {
+        version ( D_Version2 ) { }
+        else
+        {
+            // GC collect hooks only available in D1
+            GC.monitor(&this.gcCollectStart, &this.gcCollectEnd);
+        }
+
         const app_name = "dhtnode";
         const app_desc = "dhtnode: DHT server node.";
 
@@ -661,6 +670,37 @@ public class DhtNodeServer : DaemonApp
         logger.trace("Finished SIGINT handler");
 
         this.node.state = DhtNode.State.ShutDown;
+    }
+
+    version ( D_Version2 ) { }
+    else
+    {
+        /***********************************************************************
+
+            Called (in D1 builds) when a GC collection starts.
+
+        ***********************************************************************/
+
+        private void gcCollectStart ( )
+        {
+            logger.trace("Starting GC collection");
+        }
+
+        /***********************************************************************
+
+            Called (in D1 builds) when a GC collection finishes.
+
+            Params:
+                freed = the number of bytes freed overall
+                pagebytes = the number of bytes freed within full pages
+
+        ***********************************************************************/
+
+        private void gcCollectEnd ( int freed, int pagebytes )
+        {
+            logger.trace("Finished GC collection: {} bytes freed, {} bytes freed within full pages",
+                freed, pagebytes);
+        }
     }
 }
 

--- a/src/dhtnode/request/ListenRequest.d
+++ b/src/dhtnode/request/ListenRequest.d
@@ -90,12 +90,6 @@ public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
 
     private const HashBufferMaxLength = (1024 / hash_t.sizeof) * 256; // 256 Kb of hashes
 
-    /// Flag ensuring that the address of this request's FiberSelectEvent is
-    /// only written to the log once.
-    /// TODO: remove this when https://github.com/sociomantic/dhtnode/issues/741
-    /// is fixed.
-    private bool logged_event_addr;
-
     /***************************************************************************
 
         Adds this.resources and constructor to initialize it and forward
@@ -202,15 +196,6 @@ public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
 
         this.waiting_for_trigger = true;
         scope(exit) this.waiting_for_trigger = false;
-
-        if ( !this.logged_event_addr )
-        {
-            // TODO: remove this when
-            // https://github.com/sociomantic/dhtnode/issues/741 is fixed.
-            log.trace("Listen request on channel '{}' acquired FiberSelectEvent {}",
-                this.storage_channel.id, cast(void*)this.resources.event);
-            logged_event_addr = true;
-        }
 
         this.resources.event.wait;
     }

--- a/src/dhtnode/request/ListenRequest.d
+++ b/src/dhtnode/request/ListenRequest.d
@@ -90,6 +90,12 @@ public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
 
     private const HashBufferMaxLength = (1024 / hash_t.sizeof) * 256; // 256 Kb of hashes
 
+    /// Flag ensuring that the address of this request's FiberSelectEvent is
+    /// only written to the log once.
+    /// TODO: remove this when https://github.com/sociomantic/dhtnode/issues/741
+    /// is fixed.
+    private bool logged_event_addr;
+
     /***************************************************************************
 
         Adds this.resources and constructor to initialize it and forward
@@ -196,6 +202,15 @@ public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
 
         this.waiting_for_trigger = true;
         scope(exit) this.waiting_for_trigger = false;
+
+        if ( !this.logged_event_addr )
+        {
+            // TODO: remove this when
+            // https://github.com/sociomantic/dhtnode/issues/741 is fixed.
+            log.trace("Listen request on channel '{}' acquired FiberSelectEvent {}",
+                this.storage_channel.id, cast(void*)this.resources.event);
+            logged_event_addr = true;
+        }
 
         this.resources.event.wait;
     }


### PR DESCRIPTION
The commits in this PR were made against the old v1.9.x branch in the private dhtnode repo. Bringing them into v1.10.x here.

Notes:
* v1.9.9: Commit 44400b7d1e67130433bed737e80e03d49bd6135a (in the private repo) is included in the PR but reverted. The bug that it was investigating has since been fixed. (Requires a dhtproto submodule update. See #32.)
* v1.9.10: Commit fd1c23f9359d7e72d91b3acc0a4cbaa49525896e (in the private repo) was left out. It updated to the latest patch releases of submodules used by v1.9.x. This will be replaced by #32.