### PR TITLE
Add the error message in package install script and remove outdated comment

### DIFF
--- a/pkg/after_dhtnode_install.sh
+++ b/pkg/after_dhtnode_install.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
 
+# Exits with an error message
+error_exit()
+{
+    msg="$1"
+    code="$2"
+    echo "$msg" 1>&2
+    exit "$code"
+}
+
 if [ "$1" = "configure" ]; then
     addgroup --system core
     adduser --system --no-create-home dhtnode
 
     # Check that deployment directory exists
-    test -d /srv/dhtnode || exit 1
+    test -d /srv/dhtnode || error_exit "/srv/dhtnode/dhtnode-* directories missing" 1
 
     # Create directory to which dhtnode will write log files, if it does not
     # exist, and ensure proper permissions.

--- a/pkg/after_dhtnode_install.sh
+++ b/pkg/after_dhtnode_install.sh
@@ -13,7 +13,6 @@ if [ "$1" = "configure" ]; then
     do
         mkdir -p $FOLDER/data $FOLDER/etc $FOLDER/log
 
-        # TODO: adapt this when the dhtnode runs as its own user
         chown dhtnode:core $FOLDER/data $FOLDER/etc $FOLDER/log
 
         # only dhtnode (not group!) should be able to write to the log dir,


### PR DESCRIPTION
dhtnode install script relies on /srv/dhtnode/dhtnode-* structure is setup.
If it doesn't exist, instead of silent exit it should printout the error
message. Also remove outdated comment.
