### PR TITLE
Add beaver dlang install to build package stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,5 +71,6 @@ jobs:
           if: tag IS present
           env: DMD=1.081.* F=production
           script:
+              - beaver install
               - beaver bintray upload -d sociomantic-tsunami/nodes/dhtnode
                 "$ARTIFACTS_DIR"/*.deb


### PR DESCRIPTION
Since the docker service doesn't persist between stages,
we need to rebuild the docker image before pushing tags.