### PR TITLE
Pass keys to listener triggers as hash_t, instead of char[]

### DIFF
--- a/src/dhtnode/request/ListenRequest.d
+++ b/src/dhtnode/request/ListenRequest.d
@@ -47,8 +47,6 @@ public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
 {
     import dhtnode.request.model.ConstructorMixin;
 
-    import Hash = swarm.util.Hash;
-
     import ocean.core.Verify;
     import ocean.core.Enforce;
     import ocean.core.TypeConvert : downcast;
@@ -215,7 +213,7 @@ public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
 
     ***************************************************************************/
 
-    public void trigger ( Code code, cstring key )
+    public void trigger ( Code code, hash_t key )
     {
         final switch (code) with (Code)
         {
@@ -226,7 +224,7 @@ public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
                     //several times. Since the buffer is flushed often and
                     //checking the value before adding it could be a to heavy
                     //cost there's no need to do a check before adding the key.
-                    (*this.resources.hash_buffer) ~= Hash.straightToHash(key);
+                    (*this.resources.hash_buffer) ~= key;
                 }
                 else
                 {

--- a/src/dhtnode/storage/StorageEngine.d
+++ b/src/dhtnode/storage/StorageEngine.d
@@ -96,7 +96,7 @@ public class StorageEngine : IStorageEngine
 
     ***************************************************************************/
 
-    protected alias IListeners!(cstring) Listeners;
+    protected alias IListeners!(hash_t) Listeners;
 
     protected Listeners listeners;
 
@@ -186,7 +186,7 @@ public class StorageEngine : IStorageEngine
             value.ptr, castFrom!(size_t).to!(int)(value.length));
 
         if ( trigger_listeners )
-            this.listeners.trigger(Listeners.Listener.Code.DataReady, key);
+            this.listeners.trigger(Listeners.Listener.Code.DataReady, hash);
 
         return this;
     }
@@ -439,7 +439,7 @@ public class StorageEngine : IStorageEngine
 
     public override void reset ( )
     {
-        this.listeners.trigger(IListener.Code.Finish, "");
+        this.listeners.trigger(IListener.Code.Finish, 0);
     }
 
 
@@ -451,7 +451,7 @@ public class StorageEngine : IStorageEngine
 
     public override void flush ( )
     {
-        this.listeners.trigger(IListener.Code.Flush, "");
+        this.listeners.trigger(IListener.Code.Flush, 0);
     }
 
 


### PR DESCRIPTION
This saves an internal conversion from string to hash.