### PR TITLE
Use `systemctl reload` to reload config files

### DIFF
--- a/deploy/logrotate/dhtdump-logs
+++ b/deploy/logrotate/dhtdump-logs
@@ -19,6 +19,6 @@
 	maxsize 500M
 	sharedscripts
 	postrotate
-		/usr/bin/killall -HUP dhtdump
+		systemctl reload 'dhtdump@*'
 	endscript
 }

--- a/deploy/logrotate/dhtnode-logs
+++ b/deploy/logrotate/dhtnode-logs
@@ -19,6 +19,6 @@
 	maxsize 500M
 	sharedscripts
 	postrotate
-		/usr/bin/killall -HUP dhtnode
+		systemctl reload 'dht@*'
 	endscript
 }


### PR DESCRIPTION
Instead of relying on the fixed binary name, which has problems
when overriding systemd services, this relies on service name
which is fixed.