### PR TITLE
Switch to runtimebase image for Dockerfile

### DIFF
--- a/docker/Dockerfile.dhtnode
+++ b/docker/Dockerfile.dhtnode
@@ -12,9 +12,7 @@ ENV DMD=$DMD DIST=$DIST
 RUN docker/build.sh
 
 ARG DIST=xenial
-# For now plain ubuntu image is used as base for simplicity. It certainly can be
-# optimized to bare minimum but right now it is not important:
-FROM ubuntu:$DIST
+FROM sociomantictsunami/runtimebase:$DIST-v6
 COPY --from=builder /project/build/production/pkg/ /packages/
 # Installation will create /srv/dhtnode/dhtnode-0 folder and initialize it:
 COPY docker/install.sh /tmp/

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -4,13 +4,6 @@ set -xeu
 # Install dependencies
 
 apt update
-apt install -y lsb-release apt-transport-https
-
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
-echo "deb https://dl.bintray.com/sociomantic-tsunami/dlang \
-    $(lsb_release -cs) release prerelease" >> /etc/apt/sources.list.d/dlang.list
-
-apt update
 apt install -y libebtree6
 
 # Prepare folder structure and install dhtnode


### PR DESCRIPTION
Removes the need to add Sociomantic apt server manually