### PR TITLE
Switch to v7 cachalot images

### DIFF
--- a/docker/Dockerfile.dhtnode
+++ b/docker/Dockerfile.dhtnode
@@ -1,7 +1,7 @@
 # Duplicate definition of DIST before FROM is needed to be able to use it
 # in docker image name:
 ARG  DIST=xenial
-FROM sociomantictsunami/dlang:$DIST-v5 as builder
+FROM sociomantictsunami/develdlang:$DIST-v7 as builder
 # Copies the whole project as makd needs git history:
 COPY . /project/
 WORKDIR /project/
@@ -12,7 +12,7 @@ ENV DMD=$DMD DIST=$DIST
 RUN docker/build.sh
 
 ARG DIST=xenial
-FROM sociomantictsunami/runtimebase:$DIST-v6
+FROM sociomantictsunami/runtimebase:$DIST-v7
 COPY --from=builder /project/build/production/pkg/ /packages/
 # Installation will create /srv/dhtnode/dhtnode-0 folder and initialize it:
 COPY docker/install.sh /tmp/


### PR DESCRIPTION
Most important impact is that generated runtime images will include
dumb-init as the entry point.