### PR TITLE
Replace `notifemtpy` -> `ifempty` in logrotate config

### DIFF
--- a/deploy/logrotate/dhtdump-logs
+++ b/deploy/logrotate/dhtdump-logs
@@ -13,7 +13,7 @@
 	maxage 60
 
 	missingok
-	notifempty
+	ifempty
 	delaycompress
 	compress
 	maxsize 500M

--- a/deploy/logrotate/dhtnode-logs
+++ b/deploy/logrotate/dhtnode-logs
@@ -13,7 +13,7 @@
 	maxage 60
 
 	missingok
-	notifempty
+	ifempty
 	delaycompress
 	compress
 	maxsize 500M


### PR DESCRIPTION
`notifempty` causes rotated files (e.g. `some.log.1`) to not be further
rotated.

Fixes #164.