### PR TITLE
Do not fail if can't create user and group

### DIFF
--- a/pkg/after_dhtnode_install.sh
+++ b/pkg/after_dhtnode_install.sh
@@ -10,8 +10,8 @@ error_exit()
 }
 
 if [ "$1" = "configure" ]; then
-    addgroup --system core
-    adduser --system --no-create-home dhtnode
+    getent group core > /dev/null || addgroup --system core
+    getent passwd dhtnode > /dev/null || adduser --system --no-create-home dhtnode
 
     # Check that deployment directory exists
     test -d /srv/dhtnode || error_exit "/srv/dhtnode/dhtnode-* directories missing" 1


### PR DESCRIPTION
If the package postinstall script can't add user and a group (usually
because the user already exist), don't exit the after install script.

Instead ignore the error and check if the user and the group are setup
correctly.