### PR TITLE
Import HashRange directly from swarm in RedistDhtClient

### DIFF
--- a/src/dhtredist/RedistDhtClient.d
+++ b/src/dhtredist/RedistDhtClient.d
@@ -42,8 +42,9 @@ public class RedistDhtClient : SchedulingDhtClient
     import swarm.client.model.IClient;
     import swarm.client.model.ClientSettings;
     import swarm.client.connection.RequestOverflow;
+    import swarm.util.Hash : HashRange;
 
-    import dhtproto.client.legacy.DhtConst : DhtConst, HashRange, NodeHashRange;
+    import dhtproto.client.legacy.DhtConst : DhtConst, NodeHashRange;
     import dhtproto.client.legacy.internal.connection.DhtNodeConnectionPool;
     import Swarm = dhtproto.client.legacy.internal.registry.DhtNodeRegistry;
     import dhtproto.client.legacy.internal.RequestSetup;


### PR DESCRIPTION
`HashRange` is not a public import in `dhtproto.client.legacy.DhtConst`, so it is only accessible thanks to a compiler bug which makes selective imports implicitly public.

This bug has been fixed in more recent D2 compiler versions, so we need to import from swarm to guarantee access to the `HashRange` symbol.