### PR TITLE
Drop import of deprecated and unused OutOfMemoryException

### DIFF
--- a/src/dhtnode/main.d
+++ b/src/dhtnode/main.d
@@ -119,7 +119,7 @@ public class DhtNodeServer : DaemonApp
     import swarm.util.node.log.Stats;
     import swarm.util.RecordBatcher;
 
-    import ocean.core.ExceptionDefinitions : IOException, OutOfMemoryException;
+    import ocean.core.ExceptionDefinitions : IOException;
 
     import core.sys.posix.signal: SIGINT, SIGTERM, SIGQUIT;
     import core.sys.posix.sys.mman : mlockall, MCL_CURRENT, MCL_FUTURE;


### PR DESCRIPTION
This is not actually used in the codebase any more, and importing it will block upgrades to ocean v5.x.x, from which it has been dropped.

This should remove one of the blockers to https://github.com/sociomantic-tsunami/dhtnode/pull/226.