### PR TITLE
Remove usage of global recordSizeLimit constant

### DIFF
--- a/src/dhtnode/request/RedistributeRequest.d
+++ b/src/dhtnode/request/RedistributeRequest.d
@@ -359,7 +359,7 @@ public scope class RedistributeRequest : Protocol.Redistribute
             return ForwardResult.Invalid;
         }
 
-        if ( value.length >= DhtConst.RecordSizeLimit )
+        if ( value.length >= this.resources.storage_channels.batch_size )
         {
             log.warn("Removing too large record ({} bytes) {}", value.length,
                 key);

--- a/src/dhtnode/storage/StorageChannels.d
+++ b/src/dhtnode/storage/StorageChannels.d
@@ -104,7 +104,12 @@ public class StorageChannels : IStorageChannelsTemplate!(StorageEngine)
     private uint bnum;
 
 
-    /// Batch size used by legacy compressed batch requests (e.g. GetAll).
+    /***************************************************************************
+
+        Batch size used by legacy compressed batch requests (e.g. GetAll).
+
+    ***************************************************************************/
+
     private size_t batch_size_;
 
 
@@ -185,7 +190,7 @@ public class StorageChannels : IStorageChannelsTemplate!(StorageEngine)
         this.batch_size_ = batch_size;
 
         this.dump_manager = new DumpManager(this.dir, out_of_range_handling,
-            disable_direct_io);
+            disable_direct_io, this.batch_size_);
 
         this.loadChannels();
     }
@@ -209,7 +214,7 @@ public class StorageChannels : IStorageChannelsTemplate!(StorageEngine)
     /***************************************************************************
 
         Returns:
-             string identifying the type of the storage engine
+            string identifying the type of the storage engine
 
     ***************************************************************************/
 
@@ -222,7 +227,7 @@ public class StorageChannels : IStorageChannelsTemplate!(StorageEngine)
     /***************************************************************************
 
         Returns:
-             batch size used by legacy compressed batch requests (e.g. GetAll)
+            batch size used by legacy compressed batch requests (e.g. GetAll)
 
     ***************************************************************************/
 
@@ -271,7 +276,7 @@ public class StorageChannels : IStorageChannelsTemplate!(StorageEngine)
     /***************************************************************************
 
         Returns:
-             string identifying the type of the storage engine
+            string identifying the type of the storage engine
 
     ***************************************************************************/
 


### PR DESCRIPTION
Since the batch size is now configured in the nodes config file this change also makes it possible
(and necessary) to change two private methods of the DumpManager module to non static.