### PR TITLE
Remove TCP no_delay option

### DIFF
--- a/integrationtest/dhttest/etc/config.ini
+++ b/integrationtest/dhttest/etc/config.ini
@@ -23,12 +23,6 @@ unix_socket_path        = dhtnode.socket
 ; determines the speed at which such tests can run.
 write_flush_ms = 1
 
-; Disable Nagle's algorithm for neo sockets. This is important for testing
-; requests with large volumes of data -- Nagle's algorithm slows them down too
-; much, if left enabled.
-no_delay = true
-
-
 ; Memory node configuration
 
 [Options_Memory]

--- a/neotest/main.d
+++ b/neotest/main.d
@@ -37,7 +37,6 @@ class DhtTest : Task
         ubyte[] auth_key = Key.init.content;
         this.dht = new DhtClient(theScheduler.epoll, auth_name, auth_key,
             &this.connNotifier);
-        this.dht.neo.enableSocketNoDelay();
         this.dht.neo.addNode("127.0.0.1", 10_100);
     }
 

--- a/src/dhtnode/config/PerformanceConfig.d
+++ b/src/dhtnode/config/PerformanceConfig.d
@@ -40,14 +40,5 @@ public class PerformanceConfig
     ***************************************************************************/
 
     double redist_memory_limit_mulitplier = 1.1;
-
-    /***************************************************************************
-
-        For neo connections: toggles Nagle's algorithm (true = disabled, false =
-        enabled) on the underlying socket.
-
-    ***************************************************************************/
-
-    bool no_delay;
 }
 

--- a/src/dhtnode/main.d
+++ b/src/dhtnode/main.d
@@ -409,8 +409,7 @@ public class DhtNodeServer : DaemonApp
             storage, this.performance_config.redist_memory_limit_mulitplier);
 
         this.node = new DhtNode(this.server_config, this.node_item,
-            storage, this.hash_range, this.epoll, this.per_request_stats,
-            this.performance_config.no_delay);
+            storage, this.hash_range, this.epoll, this.per_request_stats);
         this.dht_stats =
             new ChannelsNodeStats(this.node, this.stats_ext.stats_log);
 

--- a/src/dhtnode/node/DhtNode.d
+++ b/src/dhtnode/node/DhtNode.d
@@ -90,15 +90,12 @@ public class DhtNode :
             hash_range = min/max hash range tracker
             epoll = epoll select dispatcher to be used internally
             per_request_stats = names of requests to be stats tracked
-            no_delay = toggle Nagle's algorithm (true = disabled, false =
-                enabled) on the connection sockets
 
     ***************************************************************************/
 
     public this ( ServerConfig server_config, NodeItem node_item,
         StorageChannels channels, DhtHashRange hash_range,
-        EpollSelectDispatcher epoll, istring[] per_request_stats,
-        bool no_delay )
+        EpollSelectDispatcher epoll, istring[] per_request_stats )
     {
         this.hash_range = hash_range;
 
@@ -117,7 +114,6 @@ public class DhtNode :
         options.epoll = epoll;
         options.requests = requests;
         options.shared_resources = this.shared_resources;
-        options.no_delay = no_delay;
         options.unix_socket_path = idup(server_config.unix_socket_path());
         options.credentials_filename = "etc/credentials";
 


### PR DESCRIPTION
The `TCP_NODELAY` is always on, independent of the configuration flag. Therefore the option is removed from the configuration. Also the method that enables `TCP_NODELAY` in swarm is deprecated and removed from the latest major release.