### PR TITLE
Add a StompingPreventionStats version constraint

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,5 +1,9 @@
 export ASSERT_ON_STOMPING_PREVENTION=1
 
+ifneq ($(DISABLE_STOMPING_STATS), 1)
+	override DFLAGS += -version=StompingPreventionStats
+endif
+
 ifeq ($F, production)
 	override DFLAGS += -release
 endif

--- a/src/dhtnode/main.d
+++ b/src/dhtnode/main.d
@@ -36,7 +36,7 @@ import core.memory;
 
 *******************************************************************************/
 
-version ( D_Version2 )
+version ( StompingPreventionStats )
 {
     mixin(`
         extern(C) extern shared long stomping_prevention_counter;
@@ -445,15 +445,15 @@ public class DhtNodeServer : DaemonApp
         this.dht_stats.log();
         this.stats_ext.stats_log.add(.Log.stats());
 
-        struct StompingPreventionStats
+        version ( StompingPreventionStats )
         {
-            long stomping_prevention_counter;
-        }
+            struct StompingPreventionStats
+            {
+                long stomping_prevention_counter;
+            }
 
-        StompingPreventionStats stomping_stats;
+            StompingPreventionStats stomping_stats;
 
-        version ( D_Version2 )
-        {
             mixin(`
                 import core.atomic : atomicLoad, atomicStore;
 
@@ -461,9 +461,10 @@ public class DhtNodeServer : DaemonApp
                     atomicLoad(.stomping_prevention_counter);
                 atomicStore(.stomping_prevention_counter, 0UL);
             `);
+
+            this.stats_ext.stats_log.add(stomping_stats);
         }
 
-        this.stats_ext.stats_log.add(stomping_stats);
         this.stats_ext.stats_log.flush();
     }
 


### PR DESCRIPTION
The `stomping_prevention_counter` global is only accessible when using `dmd-transitional`.  If we want to build with vanilla DMD or any other compiler, we cannot use this symbol, so this patch replaces the original `D_Version2` version constraint with one specific to stomping prevention stats.

By default this will be enabled in `Build.mak`, but it can be overridden by using the `DISABLE_STOMPING_STATS` environment variable.  This should ensure that current behaviour persists by default, but build for vanilla DMD (or other compilers) can be added which disable the feature.