### PR TITLE
Fix some style issues, remove to-be-deprecated code, move towards upstream

### DIFF
--- a/src/dhtnode/dhtdump/main.d
+++ b/src/dhtnode/dhtdump/main.d
@@ -12,52 +12,26 @@
 
 module dhtnode.dhtdump.main;
 
-
-
-/*******************************************************************************
-
-    Imports
-
-*******************************************************************************/
-
-import ocean.transition;
-
 import Version;
 
 import dhtnode.dhtdump.DumpCycle;
 import dhtnode.dhtdump.DumpStats;
 
-import ocean.io.select.EpollSelectDispatcher;
-
-import ocean.io.select.client.TimerEvent;
-
-import ocean.util.app.DaemonApp;
-
-import ConfigReader = ocean.util.config.ConfigFiller;
-
 import dhtproto.client.DhtClient;
-
+import dhtproto.client.legacy.internal.helper.RetryHandshake;
 import dhtproto.client.legacy.internal.registry.DhtNodeRegistry;
 
-import dhtproto.client.legacy.internal.helper.RetryHandshake;
-
+import ocean.core.Time;
+import ocean.io.select.EpollSelectDispatcher;
+import ocean.io.select.client.TimerEvent;
 import ocean.math.random.Random;
-
-import core.thread;
-
 import ocean.time.StopWatch;
-
+import ocean.transition;
+import ocean.util.app.DaemonApp;
+import ConfigReader = ocean.util.config.ConfigFiller;
 import ocean.util.log.Logger;
 
-import ocean.core.Time;
-
-
-
-/*******************************************************************************
-
-    Static module logger
-
-*******************************************************************************/
+import core.thread;
 
 private Logger log;
 
@@ -65,7 +39,6 @@ static this ( )
 {
     log = Log.lookup("dhtnode.dhtdump.main");
 }
-
 
 
 /*******************************************************************************
@@ -314,4 +287,3 @@ public class DhtDump : DaemonApp
         while ( error );
     }
 }
-

--- a/src/dhtnode/dhtdump/main.d
+++ b/src/dhtnode/dhtdump/main.d
@@ -21,7 +21,6 @@ import dhtproto.client.DhtClient;
 import dhtproto.client.legacy.internal.helper.RetryHandshake;
 import dhtproto.client.legacy.internal.registry.DhtNodeRegistry;
 
-import ocean.core.Time;
 import ocean.io.select.EpollSelectDispatcher;
 import ocean.io.select.client.TimerEvent;
 import ocean.math.random.Random;
@@ -32,6 +31,7 @@ import ConfigReader = ocean.util.config.ConfigFiller;
 import ocean.util.log.Logger;
 
 import core.thread;
+import core.time;
 
 private Logger log;
 
@@ -281,7 +281,7 @@ public class DhtDump : DaemonApp
             if ( error )
             {
                 // no fibers in existence yet, so we can just do a blocking wait
-                Thread.sleep(ocean.core.Time.seconds(retry_wait_s));
+                Thread.sleep(seconds(retry_wait_s));
             }
         }
         while ( error );

--- a/src/dhtnode/request/ListenRequest.d
+++ b/src/dhtnode/request/ListenRequest.d
@@ -46,6 +46,7 @@ static this ( )
 public scope class ListenRequest : Protocol.Listen, StorageEngine.IListener
 {
     import dhtnode.request.model.ConstructorMixin;
+    import Hash = swarm.util.Hash;
 
     import ocean.core.Verify;
     import ocean.core.Enforce;

--- a/src/dhtperformance/main.d
+++ b/src/dhtperformance/main.d
@@ -12,53 +12,33 @@
 
 module dhtperformance.main;
 
+import Version;
 
+import dhtproto.client.DhtClient;
+import dhtproto.client.legacy.DhtConst;
 
-/*******************************************************************************
+import swarm.Const;
 
-    Imports
-
-*******************************************************************************/
-
+import ocean.core.Array;
+import ocean.core.Time;
+import ocean.io.Stdout;
+import ocean.io.Terminal;
+import ocean.io.console.Tables;
+import ocean.io.select.EpollSelectDispatcher;
+import ocean.io.select.timeout.TimerEventTimeoutManager;
+import ocean.text.Arguments;
+import ocean.text.convert.Formatter;
+import Integer = ocean.text.convert.Integer_tango;
+import ocean.time.StopWatch;
 import ocean.transition;
-
-private import Version;
-
-private import ocean.io.Stdout;
-private import ocean.io.Terminal;
-private import ocean.io.console.Tables;
-
-private import ocean.io.select.EpollSelectDispatcher;
-private import ocean.io.select.timeout.TimerEventTimeoutManager;
-
-private import ocean.text.Arguments;
-
-private import ocean.text.convert.Formatter;
-
-private import ocean.util.app.Application;
-private import ocean.util.app.CliApp;
-private import ocean.util.log.StaticTrace;
-
-private import ocean.math.SlidingAverage;
-private import ocean.math.Distribution;
-
-private import swarm.Const;
-
-private import dhtproto.client.DhtClient;
-
-private import dhtproto.client.legacy.DhtConst;
-
-private import core.thread;
-
-private import ocean.time.StopWatch;
-
-private import Integer = ocean.text.convert.Integer_tango;
+import ocean.util.app.Application;
+import ocean.util.app.CliApp;
+import ocean.util.log.StaticTrace;
+import ocean.math.SlidingAverage;
+import ocean.math.Distribution;
 
 import core.sys.posix.time: timespec, nanosleep;
-
-import ocean.core.Time;
-import ocean.core.Array;
-
+import core.thread;
 
 /*******************************************************************************
 
@@ -75,8 +55,6 @@ int main ( istring[] cl_args )
     auto app = new DhtPerformance;
     return app.main(cl_args);
 }
-
-
 
 /*******************************************************************************
 

--- a/src/dhtperformance/main.d
+++ b/src/dhtperformance/main.d
@@ -20,7 +20,6 @@ import dhtproto.client.legacy.DhtConst;
 import swarm.Const;
 
 import ocean.core.Array;
-import ocean.core.Time;
 import ocean.io.Stdout;
 import ocean.io.Terminal;
 import ocean.io.console.Tables;
@@ -39,6 +38,7 @@ import ocean.math.Distribution;
 
 import core.sys.posix.time: timespec, nanosleep;
 import core.thread;
+import core.time;
 
 /*******************************************************************************
 
@@ -726,7 +726,7 @@ private class DhtPerformance : CliApp
 
         while (error)
         {
-            Thread.sleep(ocean.core.Time.seconds(this.retry_delay));
+            Thread.sleep(seconds(this.retry_delay));
             error = this.handshake(xml, client, false);
         }
 


### PR DESCRIPTION
Each of those commits do a different thing, as mentioned in the title.
My end goal is to have `dhtnode` compile with upstream DMD (for the moment it still depends on `dmd-transitional`).
Using Ocean v5.4.0 is required to avoid the flood of deprecations that is triggered otherwise.