### PR TITLE
Drop compatibility for anything less than v2.092 & xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ git:
 # Global environment variables
 env:
     global:
-        - DIST=xenial
-        - COV=1
+        - DIST=bionic
+        - COV=0
         # Default beaver image names. May be overriden in specific stages
         - BEAVER_DOCKER_IMG=builder
         - BEAVER_DOCKER_CONTEXT=docker/builder
@@ -48,28 +48,20 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DIST=xenial DMD=2.078.3.s* F=production
+          env: DMD=2.092.* F=production
         - <<: *test-matrix
-          env: DIST=xenial DMD=2.078.3.s* F=devel
+          env: DMD=2.092.* F=devel
         - <<: *test-matrix
-          env: DIST=bionic DMD=2.085.* F=production
+          env: DMD=2.093.* F=production COV=1
         - <<: *test-matrix
-          env: DIST=bionic DMD=2.085.* F=devel
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.092.* F=production
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.092.* F=devel
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.093.* F=production
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.093.* F=devel
+          env: DMD=2.093.* F=devel COV=1
 
         # Test deployment docker image generation
         - stage: Test
           script:
-              - docker build --build-arg DMD=2.078.3.s* --build-arg DIST=xenial
+              - docker build --build-arg DMD=2.093.* --build-arg DIST=${DIST}
                 -t dhtnode -f docker/Dockerfile.dhtnode .
 
         # Package matrix
         - <<: *package-matrix
-          env: DMD=2.078.3.s* F=production COV=0
+          env: DMD=2.093.* F=production

--- a/Build.mak
+++ b/Build.mak
@@ -1,9 +1,3 @@
-export ASSERT_ON_STOMPING_PREVENTION=1
-
-ifneq ($(DISABLE_STOMPING_STATS), 1)
-	override DFLAGS += -version=StompingPreventionStats
-endif
-
 ifeq ($F, production)
 	override DFLAGS += -release
 endif

--- a/Config.mak
+++ b/Config.mak
@@ -1,4 +1,1 @@
-DC := dmd-transitional
 DVER := 2
-# Emulates Jenkins' behavior by default
-PKG_SUFFIX ?= -d$(DVER)

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -9,5 +9,4 @@ apt install -y libebtree6
 # Prepare folder structure and install dhtnode
 
 mkdir -p /srv/dhtnode/dhtnode-0
-apt install -y /packages/dhtnode-d*.deb
-ln -s /usr/sbin/dhtnode-* /usr/sbin/dhtnode
+apt install -y /packages/dhtnode*.deb

--- a/src/dhtnode/main.d
+++ b/src/dhtnode/main.d
@@ -29,22 +29,6 @@ import ocean.util.log.Logger;
 import core.memory;
 
 
-
-/*******************************************************************************
-
-    D2-only stomping prevention counter
-
-*******************************************************************************/
-
-version ( StompingPreventionStats )
-{
-    mixin(`
-        extern(C) extern shared long stomping_prevention_counter;
-    `);
-}
-
-
-
 /*******************************************************************************
 
     Static module logger
@@ -444,27 +428,6 @@ public class DhtNodeServer : DaemonApp
         this.reportSystemStats();
         this.dht_stats.log();
         this.stats_ext.stats_log.add(.Log.stats());
-
-        version ( StompingPreventionStats )
-        {
-            struct StompingPreventionStats
-            {
-                long stomping_prevention_counter;
-            }
-
-            StompingPreventionStats stomping_stats;
-
-            mixin(`
-                import core.atomic : atomicLoad, atomicStore;
-
-                stomping_stats.stomping_prevention_counter =
-                    atomicLoad(.stomping_prevention_counter);
-                atomicStore(.stomping_prevention_counter, 0UL);
-            `);
-
-            this.stats_ext.stats_log.add(stomping_stats);
-        }
-
         this.stats_ext.stats_log.flush();
     }
 
@@ -707,4 +670,3 @@ public class DhtNodeServer : DaemonApp
         }
     }
 }
-


### PR DESCRIPTION
```
Since we want to drop support for dmd-transitional,
we need to settle on the minimum supported version of DMD.
Due to the various deprecations and some codeggen bugs in -O -inline,
only v2.092.0 and higher is able to compile our code correctly.

Additionally we now only test on bionic instead of xenial,
and reduced coverage to only the latest version of the compiler.
```